### PR TITLE
Multifile upload support

### DIFF
--- a/osgeo_importer/api.py
+++ b/osgeo_importer/api.py
@@ -34,6 +34,7 @@ class UploadedLayerResource(ModelResource):
     fields = ListField(attribute='fields')
     status = CharField(attribute='status', readonly=True, null=True)
     file_type = CharField(attribute='file_type', readonly=True)
+    file_name = CharField(attribute='file_name', readonly=True)
 
     class Meta:
         queryset = UploadLayer.objects.all()

--- a/osgeo_importer/api.py
+++ b/osgeo_importer/api.py
@@ -80,7 +80,7 @@ class UploadedLayerResource(ModelResource):
         if not configuration_options:
             raise ImmediateHttpResponse(response=http.HttpBadRequest('Configuration options missing.'))
 
-        uploaded_file = obj.upload.uploadfile_set.first()
+        uploaded_file = obj.upload_file
         import_result = import_object.delay(uploaded_file.id, configuration_options=configuration_options)
 
         # query the db again for this object since it may have been updated during the import

--- a/osgeo_importer/api.py
+++ b/osgeo_importer/api.py
@@ -35,6 +35,7 @@ class UploadedLayerResource(ModelResource):
     status = CharField(attribute='status', readonly=True, null=True)
     file_type = CharField(attribute='file_type', readonly=True)
     file_name = CharField(attribute='file_name', readonly=True)
+    layer_name = CharField(attribute='layer_name', readonly=True)
 
     class Meta:
         queryset = UploadLayer.objects.all()

--- a/osgeo_importer/api.py
+++ b/osgeo_importer/api.py
@@ -50,17 +50,15 @@ class UploadedLayerResource(ModelResource):
     def clean_configuration_options(self, request, obj, configuration_options):
         return configuration_options
 
-    def import_layer(self, request, **kwargs):
-        """
-        Imports a layer
+    def import_layer(self, request, pk=None, **kwargs):
+        """Imports a layer
         """
         self.method_check(request, allowed=['post'])
 
-        b = Bundle()
-        b.request = request
+        bundle = Bundle(request=request)
 
         try:
-            obj = self.obj_get(b, pk=kwargs.get('pk'))
+            obj = self.obj_get(bundle, pk=pk)
         except UploadLayer.DoesNotExist:
             raise ImmediateHttpResponse(response=http.HttpNotFound())
 
@@ -84,7 +82,7 @@ class UploadedLayerResource(ModelResource):
         import_result = import_object.delay(uploaded_file.id, configuration_options=configuration_options)
 
         # query the db again for this object since it may have been updated during the import
-        obj = self.obj_get(b, pk=kwargs.get('pk'))
+        obj = self.obj_get(bundle, pk=pk)
         obj.task_id = import_result.id
         obj.save()
 

--- a/osgeo_importer/api.py
+++ b/osgeo_importer/api.py
@@ -33,6 +33,7 @@ class UploadedLayerResource(ModelResource):
     configuration_options = DictField(attribute='configuration_options', null=True)
     fields = ListField(attribute='fields')
     status = CharField(attribute='status', readonly=True, null=True)
+    file_type = CharField(attribute='file_type', readonly=True)
 
     class Meta:
         queryset = UploadLayer.objects.all()

--- a/osgeo_importer/api.py
+++ b/osgeo_importer/api.py
@@ -115,7 +115,7 @@ class UploadedDataResource(ModelResource):
     """
 
     user = ForeignKey(UserResource, 'user')
-    file_size = CharField(attribute='filesize', readonly=True)
+    file_size = CharField(attribute='filesize', readonly=True, null=True)
     layers = ToManyField(UploadedLayerResource, 'uploadlayer_set', full=True)
     file_url = CharField(attribute='file_url', readonly=True, null=True)
 

--- a/osgeo_importer/forms.py
+++ b/osgeo_importer/forms.py
@@ -28,16 +28,13 @@ class UploadFileForm(forms.Form):
 
         # Create list of all potentially valid files, exploding first level zip files
         for file in files:
-            logger.debug('cleaning %s',file.name)
             if not validate_extension(file.name):
                 self.add_error('file','Filetype not supported.')
-                logger.debug('Filetype not supported')
                 continue
 
             if is_zipfile(file):
                 with ZipFile(file) as zip:
                     for zipname in zip.namelist():
-                        logger.debug('Checking extensions in zipfile %s file %s',file,zipname)
                         if not validate_extension(zipname):
                             self.add_error('file','Filetype in zip not supported.')
                             continue
@@ -48,11 +45,9 @@ class UploadFileForm(forms.Form):
         # Make sure shapefiles have all their parts
         if not validate_shapefiles_have_all_parts(validfiles):
             self.add_error('file','Shapefiles must include .shp,.dbf,.shx,.prj')
-        logger.debug('valid files found: %s',validfiles)
         # Unpack all zip files and create list of cleaned file objects
         cleaned_files = []
         for file in files:
-            logger.debug('file: %s',file)
             if file.name in validfiles:
                 with open(os.path.join(outputdir,file.name),'w') as outfile:
                     for chunk in file.chunks():
@@ -70,12 +65,10 @@ class UploadFileForm(forms.Form):
         # After moving files in place make sure they can be opened by inspector
         inspected_files = []
         for cleaned_file in cleaned_files:
-            logger.debug('About to inspect %s in form',os.path.join(outputdir,cleaned_file.name))
             if not validate_inspector_can_read(os.path.join(outputdir,file.name)):
                 self.add_error('file','Inspector could not read file or file is empty')
                 continue
             inspected_files.append(cleaned_file)
 
-        logger.debug('inspected_files %s',inspected_files)
         cleaned_data['file'] = inspected_files
         return cleaned_data

--- a/osgeo_importer/forms.py
+++ b/osgeo_importer/forms.py
@@ -60,8 +60,12 @@ class UploadFileForm(forms.Form):
         # After moving files in place make sure they can be opened by inspector
         inspected_files = []
         for cleaned_file in cleaned_files:
-            if not validate_inspector_can_read(os.path.join(outputdir, cleaned_file.name)):
-                self.add_error('file', 'Inspector could not read file %s or file is empty'%(os.path.join(outputdir,file.name)))
+            cleaned_file_path = os.path.join(outputdir, cleaned_file.name)
+            if not validate_inspector_can_read(cleaned_file_path):
+                self.add_error(
+                    'file',
+                    'Inspector could not read file {} or file is empty'.format(cleaned_file_path)
+                )
                 continue
             inspected_files.append(cleaned_file)
 

--- a/osgeo_importer/forms.py
+++ b/osgeo_importer/forms.py
@@ -1,9 +1,81 @@
+import os
 from django import forms
 from .models import UploadFile
+import zipfile
+import tempfile
 
 
-class UploadFileForm(forms.ModelForm):
+class XXXUploadFileForm(forms.ModelForm):
 
     class Meta:
         model = UploadFile
         fields = ['file']
+
+class UploadFileForm(forms.Form):
+    file = forms.FileField(widget=forms.ClearableFileInput(attrs={'multiple': True}))
+    
+    def validate_extension(filename):
+        base, extension = os.path.splitext(filename)
+        extension = extension.lstrip('.').lower()
+        if extension not in OSGEO_IMPORTER_VALID_EXTENSIONS:
+            raise forms.ValidationError("%s files not accepted by importer. file: %s" % (extension, filename))
+    
+    def validate_shapefile_has_all_parts(self,validfiles):
+        shp = []
+        prj = []
+        dbf = []
+        shx = []
+        for file in validfiles:
+            base, extension = os.path.splitext(filename)
+            extension = extension.lstrip('.').lower()
+            if extension == 'shp':
+                shp.push(base)
+            elif extension == 'prj':
+                prj.push(base)
+            elif extension == 'dbf':
+                dbf.push(base)
+            elif extension == 'shx':
+                shx.push(base)
+        if set(shp) == set(prj) == set(dbf) == set(shx):
+            return True
+        else:
+            raise forms.ValidationError("All Shapefiles must include .shp, .prj, .dbf, and .shx")
+
+    def clean(self):
+        cleaned_data = super(UploadFileForm, self).clean()
+        outputdir = tempfile.mkdtemp()
+        files = self.files.getlist('files')
+        validfiles = []
+
+        # Create list of all potentially valid files, exploding first level zip files
+        for file in files:
+            self.validate_extension(file_ext)
+
+            if zipfile.is_zipfile(file):
+                with zipfile.ZipFile(file) as zip:
+                    for zipfile in zip.namelist():
+                        zipfile_base, zipfile_ext = os.path.splitext(zipfile)
+                        self.validate_extension(zipfile_ext)
+                        validfiles.push(zipfile)
+            else:
+                validfiles.push(file.name)
+
+        # Make sure shapefiles have all their parts
+        self.validate_shapefile_has_all_parts(validfiles)
+
+        # Unpack all zip files and create list of cleaned file objects
+        cleaned_files = []
+        for file in files:
+            if file in validfiles:
+                # with open(os.path.join(outputdir,file.name),'w') as outfile:
+                #    outfile.write(file.read())
+                cleaned_files.push(file)
+            elif zipfile.is_zipfile(file):
+                with zipfile.ZipFile(file) as zip:
+                    for zipfile in zip.namelist():
+                        if zipfile in validfiles:
+                            with zip.open(zipfile) as f:
+                                with open(os.path.join(outputdir,zipfile)) as outfile:
+                                    shutil.copyfileobj(f,outfile)
+                                    cleaned_files.push(outfile)
+        cleaned_data['files'] = cleaned_files

--- a/osgeo_importer/forms.py
+++ b/osgeo_importer/forms.py
@@ -6,7 +6,6 @@ from zipfile import is_zipfile, ZipFile
 import tempfile
 import logging
 import shutil
-
 logger = logging.getLogger(__name__)
 
 
@@ -18,7 +17,6 @@ class UploadFileForm(forms.Form):
         fields = ['file']
 
     def clean(self):
-        logger.debug('..Cleaning...')
         cleaned_data = super(UploadFileForm, self).clean()
         outputdir = tempfile.mkdtemp()
         files = self.files.getlist('file')
@@ -39,7 +37,6 @@ class UploadFileForm(forms.Form):
                         validfiles.append(zipname)
             else:
                 validfiles.append(file.name)
-
         # Make sure shapefiles have all their parts
         if not validate_shapefiles_have_all_parts(validfiles):
             self.add_error('file', 'Shapefiles must include .shp,.dbf,.shx,.prj')
@@ -63,8 +60,8 @@ class UploadFileForm(forms.Form):
         # After moving files in place make sure they can be opened by inspector
         inspected_files = []
         for cleaned_file in cleaned_files:
-            if not validate_inspector_can_read(os.path.join(outputdir, file.name)):
-                self.add_error('file', 'Inspector could not read file or file is empty')
+            if not validate_inspector_can_read(os.path.join(outputdir, cleaned_file.name)):
+                self.add_error('file', 'Inspector could not read file %s or file is empty'%(os.path.join(outputdir,file.name)))
                 continue
             inspected_files.append(cleaned_file)
 

--- a/osgeo_importer/forms.py
+++ b/osgeo_importer/forms.py
@@ -1,9 +1,15 @@
 import os
 from django import forms
 from .models import UploadFile
-import zipfile
+from .utils import NoDataSourceFound, load_handler
+from .importers import OSGEO_IMPORTER
+from zipfile import is_zipfile, ZipFile
 import tempfile
+import logging
+import shutil
+from django.conf import settings
 
+logger = logging.getLogger(__name__)
 
 class XXXUploadFileForm(forms.ModelForm):
 
@@ -13,12 +19,17 @@ class XXXUploadFileForm(forms.ModelForm):
 
 class UploadFileForm(forms.Form):
     file = forms.FileField(widget=forms.ClearableFileInput(attrs={'multiple': True}))
-    
-    def validate_extension(filename):
+
+    class Meta:
+        model = UploadFile
+        fields = ['file']
+
+    def validate_extension(self,filename):
         base, extension = os.path.splitext(filename)
         extension = extension.lstrip('.').lower()
-        if extension not in OSGEO_IMPORTER_VALID_EXTENSIONS:
-            raise forms.ValidationError("%s files not accepted by importer. file: %s" % (extension, filename))
+        if extension not in settings.OSGEO_IMPORTER_VALID_EXTENSIONS:
+            logger.debug('Validation Error: %s files not accepted by importer. file: %s',extension,filename)
+            self.add_error('file',"%s files not accepted by importer. file: %s" % (extension, filename))
     
     def validate_shapefile_has_all_parts(self,validfiles):
         shp = []
@@ -26,56 +37,76 @@ class UploadFileForm(forms.Form):
         dbf = []
         shx = []
         for file in validfiles:
-            base, extension = os.path.splitext(filename)
+            base, extension = os.path.splitext(file)
             extension = extension.lstrip('.').lower()
             if extension == 'shp':
-                shp.push(base)
+                shp.append(base)
             elif extension == 'prj':
-                prj.push(base)
+                prj.append(base)
             elif extension == 'dbf':
-                dbf.push(base)
+                dbf.append(base)
             elif extension == 'shx':
-                shx.push(base)
+                shx.append(base)
         if set(shp) == set(prj) == set(dbf) == set(shx):
             return True
         else:
-            raise forms.ValidationError("All Shapefiles must include .shp, .prj, .dbf, and .shx")
+            logger.debug('Validation Error: All Shapefiles must include .shp, .prj, .dbf, and .shx')
+            self.add_error('file',"All Shapefiles must include .shp, .prj, .dbf, and .shx")
+
+    def validate_inspector_can_read(self,filename):
+        try:
+            importer = load_handler(OSGEO_IMPORTER, filename)
+            data, inspector = importer.open_source_datastore(filename)
+        except NoDataSourceFound:
+            self.add_error('file','Unable to open file: %s' % filename)
 
     def clean(self):
+        logger.debug('..Cleaning...')
         cleaned_data = super(UploadFileForm, self).clean()
         outputdir = tempfile.mkdtemp()
-        files = self.files.getlist('files')
+        files = self.files.getlist('file')
         validfiles = []
 
         # Create list of all potentially valid files, exploding first level zip files
         for file in files:
-            self.validate_extension(file_ext)
+            logger.debug('cleaning %s',file.name)
+            self.validate_extension(file.name)
 
-            if zipfile.is_zipfile(file):
-                with zipfile.ZipFile(file) as zip:
-                    for zipfile in zip.namelist():
-                        zipfile_base, zipfile_ext = os.path.splitext(zipfile)
-                        self.validate_extension(zipfile_ext)
-                        validfiles.push(zipfile)
+            if is_zipfile(file):
+                with ZipFile(file) as zip:
+                    for zipname in zip.namelist():
+                        logger.debug('Checking extensions in zipfile %s file %s',file,zipname)
+                        self.validate_extension(zipname)
+                        validfiles.append(zipname)
             else:
-                validfiles.push(file.name)
+                validfiles.append(file.name)
 
         # Make sure shapefiles have all their parts
         self.validate_shapefile_has_all_parts(validfiles)
-
+        logger.debug('valid files found: %s',validfiles)
         # Unpack all zip files and create list of cleaned file objects
         cleaned_files = []
         for file in files:
-            if file in validfiles:
-                # with open(os.path.join(outputdir,file.name),'w') as outfile:
-                #    outfile.write(file.read())
-                cleaned_files.push(file)
-            elif zipfile.is_zipfile(file):
-                with zipfile.ZipFile(file) as zip:
+            logger.debug('file: %s',file)
+            if file.name in validfiles:
+                with open(os.path.join(outputdir,file.name),'w') as outfile:
+                    for chunk in file.chunks():
+                        outfile.write(chunk)
+                cleaned_files.append(outfile)
+            elif is_zipfile(file):
+                with ZipFile(file) as zip:
                     for zipfile in zip.namelist():
                         if zipfile in validfiles:
                             with zip.open(zipfile) as f:
-                                with open(os.path.join(outputdir,zipfile)) as outfile:
+                                with open(os.path.join(outputdir,zipfile),'w') as outfile:
                                     shutil.copyfileobj(f,outfile)
-                                    cleaned_files.push(outfile)
-        cleaned_data['files'] = cleaned_files
+                                    cleaned_files.append(outfile)
+
+        # After moving files in place make sure they can be opened by inspector
+        for cleaned_file in cleaned_files:
+            logger.debug('About to inspect %s in form',os.path.join(outputdir,file.name))
+            self.validate_inspector_can_read(os.path.join(outputdir,file.name))
+
+        logger.debug('cleaned_files %s',cleaned_files)
+        cleaned_data['file'] = cleaned_files
+        return cleaned_data

--- a/osgeo_importer/handlers/__init__.py
+++ b/osgeo_importer/handlers/__init__.py
@@ -11,7 +11,8 @@ DEFAULT_IMPORT_HANDLERS = ['osgeo_importer.handlers.FieldConverterHandler',
                            'osgeo_importer.handlers.geoserver.GeoServerBoundsHandler',
                            'osgeo_importer.handlers.geoserver.GenericSLDHandler',
                            'osgeo_importer.handlers.geonode.GeoNodePublishHandler',
-                           'osgeo_importer.handlers.geoserver.GeoServerStyleHandler']
+                           'osgeo_importer.handlers.geoserver.GeoServerStyleHandler',
+                           'osgeo_importer.handlers.geonode.GeoNodeMetadataHandler']
 
 IMPORT_HANDLERS = getattr(settings, 'IMPORT_HANDLERS', DEFAULT_IMPORT_HANDLERS)
 

--- a/osgeo_importer/handlers/__init__.py
+++ b/osgeo_importer/handlers/__init__.py
@@ -10,7 +10,8 @@ DEFAULT_IMPORT_HANDLERS = ['osgeo_importer.handlers.FieldConverterHandler',
                            'osgeo_importer.handlers.geoserver.GeoWebCacheHandler',
                            'osgeo_importer.handlers.geoserver.GeoServerBoundsHandler',
                            'osgeo_importer.handlers.geoserver.GenericSLDHandler',
-                           'osgeo_importer.handlers.geonode.GeoNodePublishHandler']
+                           'osgeo_importer.handlers.geonode.GeoNodePublishHandler',
+                           'osgeo_importer.handlers.geoserver.GeoServerStyleHandler']
 
 IMPORT_HANDLERS = getattr(settings, 'IMPORT_HANDLERS', DEFAULT_IMPORT_HANDLERS)
 

--- a/osgeo_importer/handlers/geonode/__init__.py
+++ b/osgeo_importer/handlers/geonode/__init__.py
@@ -4,6 +4,8 @@ from osgeo_importer.handlers import ImportHandlerMixin
 from osgeo_importer.handlers import ensure_can_run
 from osgeo_importer.importers import UPLOAD_DIR
 from geonode.geoserver.helpers import gs_slurp
+from geonode.layers.metadata import set_metadata
+from geonode.layers.utils import resolve_regions
 from django.contrib.auth import get_user_model
 from django.conf import settings
 from django import db
@@ -65,7 +67,7 @@ class GeoNodePublishHandler(ImportHandlerMixin):
 
         if self.importer.upload_file and results['layers'][0]['status'] == 'created':
             matched_layer = Layer.objects.get(name=results['layers'][0]['name'])
-            upload_layer = UploadLayer.objects.get(upload=self.importer.upload_file.upload,
+            upload_layer = UploadLayer.objects.get(upload_file=self.importer.upload_file.pk,
                                                    index=layer_config.get('index'))
             upload_layer.layer = matched_layer
             upload_layer.save()
@@ -82,7 +84,6 @@ class GeoNodeMetadataHandler(ImportHandlerMixin):
         Only run this handler if the layer is found in Geoserver and the layer's style is the generic style.
         """
         if not layer_config.get('metadata', None):
-            # logger.debug('Could not find any metadata xml in config %s', layer_config)
             return False
 
         return True
@@ -117,7 +118,6 @@ class GeoNodeMetadataHandler(ImportHandlerMixin):
                 # value = SpatialRepresentationType.objects.get(identifier=value)
                 pass
             else:
-                logger.debug('Adding Metadata %s %s %s', geonode_layer, key, value)
                 setattr(geonode_layer, key, value)
 
         geonode_layer.save()

--- a/osgeo_importer/handlers/geonode/__init__.py
+++ b/osgeo_importer/handlers/geonode/__init__.py
@@ -74,6 +74,7 @@ class GeoNodePublishHandler(ImportHandlerMixin):
 
         return results
 
+
 class GeoNodeMetadataHandler(ImportHandlerMixin):
     """
     Import uploaded XML

--- a/osgeo_importer/handlers/geonode/__init__.py
+++ b/osgeo_importer/handlers/geonode/__init__.py
@@ -76,8 +76,7 @@ class GeoNodePublishHandler(ImportHandlerMixin):
 
 
 class GeoNodeMetadataHandler(ImportHandlerMixin):
-    """
-    Import uploaded XML
+    """Import uploaded XML
     """
 
     def can_run(self, layer, layer_config, *args, **kwargs):
@@ -91,8 +90,7 @@ class GeoNodeMetadataHandler(ImportHandlerMixin):
 
     @ensure_can_run
     def handle(self, layer, layer_config, *args, **kwargs):
-        """
-        Update metadata from xml
+        """Update metadata from XML
         """
         geonode_layer = Layer.objects.get(name=layer)
         path = os.path.join(UPLOAD_DIR, str(self.importer.upload_file.upload.id))

--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -337,8 +337,7 @@ class GenericSLDHandler(GeoserverHandlerMixin):
 
 
 class GeoServerStyleHandler(GeoserverHandlerMixin):
-    """
-    Adds styles to GeoServer Layer
+    """Adds styles to GeoServer Layer
     """
     catalog = gs_catalog
     catalog._cache.clear()

--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -5,6 +5,7 @@ from decimal import Decimal, InvalidOperation
 from django import db
 from django.conf import settings
 from osgeo_importer.handlers import ImportHandlerMixin, GetModifiedFieldsMixin, ensure_can_run
+from osgeo_importer.importers import UPLOAD_DIR
 from geoserver.catalog import FailedRequestError, ConflictingDataError
 from geonode.geoserver.helpers import gs_catalog
 from geoserver.support import DimensionInfo
@@ -361,7 +362,7 @@ class GeoServerStyleHandler(GeoserverHandlerMixin):
         "slds": SLDS to add to layer
         """
         lyr = self.catalog.get_layer(layer)
-        path = os.path.join(FileSystemStorage().location,'osgeo_importer_uploads', str(self.importer.upload_file.upload.id))
+        path = os.path.join(UPLOAD_DIR, str(self.importer.upload_file.upload.id))
         default_sld = layer_config.get('default_style', None)
         slds = layer_config.get('styles', None)
         all_slds = []

--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -8,9 +8,7 @@ from osgeo_importer.handlers import ImportHandlerMixin, GetModifiedFieldsMixin, 
 from osgeo_importer.importers import UPLOAD_DIR
 from geoserver.catalog import FailedRequestError, ConflictingDataError
 from geonode.geoserver.helpers import gs_catalog
-from geonode.layers.utils import resolve_regions
 from geoserver.support import DimensionInfo
-from django.core.files.storage import FileSystemStorage
 from osgeo_importer.utils import increment_filename
 
 

--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -5,9 +5,12 @@ from decimal import Decimal, InvalidOperation
 from django import db
 from django.conf import settings
 from osgeo_importer.handlers import ImportHandlerMixin, GetModifiedFieldsMixin, ensure_can_run
-from geoserver.catalog import FailedRequestError
+from geoserver.catalog import FailedRequestError, ConflictingDataError
 from geonode.geoserver.helpers import gs_catalog
 from geoserver.support import DimensionInfo
+from django.core.files.storage import FileSystemStorage
+from osgeo_importer.utils import increment_filename
+
 
 logger = logging.getLogger(__name__)
 
@@ -331,3 +334,65 @@ class GenericSLDHandler(GeoserverHandlerMixin):
         """
         self.layer.default_style = 'point'
         self.catalog.save(self.layer)
+
+
+class GeoServerStyleHandler(GeoserverHandlerMixin):
+    """
+    Adds styles to GeoServer Layer
+    """
+    catalog = gs_catalog
+    catalog._cache.clear()
+    workspace = 'geonode'
+
+    def can_run(self, layer, layer_config, *args, **kwargs):
+        """
+        Returns true if the configuration has enough information to run the handler.
+        """
+        if not any([layer_config.get('default_style', None), layer_config.get('styles', None)]):
+            return False
+
+        return True
+
+    @ensure_can_run
+    def handle(self, layer, layer_config, *args, **kwargs):
+        """
+        Handler specific params:
+        "default_sld": SLD to load as default_sld
+        "slds": SLDS to add to layer
+        """
+        lyr = self.catalog.get_layer(layer)
+        path = os.path.join(FileSystemStorage().location,'osgeo_importer_uploads', str(self.importer.upload_file.upload.id))
+        default_sld = layer_config.get('default_style', None)
+        slds = layer_config.get('styles', None)
+        all_slds = []
+        if default_sld is not None:
+            slds.append(default_sld)
+
+        all_slds = list(set(slds))
+        # all_slds = [CheckFile(x) for x in all_slds if x is not None]
+
+        styles = []
+        default_style = None
+        for sld in all_slds:
+            with open(os.path.join(path, sld)) as s:
+                n = 0
+                sldname = os.path.splitext(sld)[0]
+                while True:
+                    n += 1
+                    try:
+                        self.catalog.create_style(sldname, s.read(), overwrite=False, workspace=self.workspace)
+                    except ConflictingDataError:
+                        sldname = increment_filename(sldname)
+                    if n >= 100:
+                        break
+
+                style = self.catalog.get_style(sldname, workspace=self.workspace)
+                if sld == default_sld:
+                    default_style = style
+                styles.append(style)
+
+        lyr.styles = list(set(lyr.styles + styles))
+        if default_style is not None:
+            lyr.default_style = default_style
+        self.catalog.save(lyr)
+        return {'default_style': default_style.filename}

--- a/osgeo_importer/handlers/geoserver/__init__.py
+++ b/osgeo_importer/handlers/geoserver/__init__.py
@@ -8,6 +8,7 @@ from osgeo_importer.handlers import ImportHandlerMixin, GetModifiedFieldsMixin, 
 from osgeo_importer.importers import UPLOAD_DIR
 from geoserver.catalog import FailedRequestError, ConflictingDataError
 from geonode.geoserver.helpers import gs_catalog
+from geonode.layers.utils import resolve_regions
 from geoserver.support import DimensionInfo
 from django.core.files.storage import FileSystemStorage
 from osgeo_importer.utils import increment_filename

--- a/osgeo_importer/importers.py
+++ b/osgeo_importer/importers.py
@@ -25,9 +25,10 @@ ogr.UseExceptions()
 
 MEDIA_ROOT = getattr(settings, 'MEDIA_ROOT', FileSystemStorage().location)
 OSGEO_IMPORTER = getattr(settings, 'OSGEO_IMPORTER', 'osgeo_importer.importers.OGRImport')
-VALID_EXTENSIONS = getattr(settings, 'OSGEO_IMPORTER_VALID_EXTENSIONS',
-                           ['shp', 'shx', 'prj', 'dbf', 'kml', 'geojson', 'json',
-                            'tif', 'tiff', 'gpkg', 'csv', 'zip', 'xml', 'sld'])
+DEFAULT_SUPPORTED_EXTENSIONS = ['shp', 'shx', 'prj', 'dbf', 'kml', 'geojson', 'json',
+                                'tif', 'tiff', 'gpkg', 'csv', 'zip', 'xml', 'sld']
+VALID_EXTENSIONS = getattr(settings, 'OSGEO_IMPORTER_VALID_EXTENSIONS', DEFAULT_SUPPORTED_EXTENSIONS)
+
 RASTER_FILES = getattr(settings, 'OSGEO_IMPORTER_RASTER_FILES', os.path.join(MEDIA_ROOT, 'osgeo_importer_raster'))
 UPLOAD_DIR = getattr(settings, 'OSGEO_IMPORTER_UPLOAD_DIR', os.path.join(MEDIA_ROOT, 'osgeo_importer_uploads'))
 

--- a/osgeo_importer/importers.py
+++ b/osgeo_importer/importers.py
@@ -17,14 +17,25 @@ from .handlers import IMPORT_HANDLERS
 from django.conf import settings
 from django import db
 import logging
+from django.core.files.storage import FileSystemStorage
+
 
 logger = logging.getLogger(__name__)
 ogr.UseExceptions()
 
-
+MEDIA_ROOT = getattr(settings, 'MEDIA_ROOT', FileSystemStorage().location)
 OSGEO_IMPORTER = getattr(settings, 'OSGEO_IMPORTER', 'osgeo_importer.importers.OGRImport')
-RASTER_FILES = getattr(settings, 'RASTER_FILES', '/tmp')
+VALID_EXTENSIONS = getattr(settings, 'OSGEO_IMPORTER_VALID_EXTENSIONS', 
+                           ['shp','shx','prj','dbf','kml','geojson','json',
+                           'tif','tiff','gpkg','csv','zip','xml','sld'])
+RASTER_FILES = getattr(settings, 'OSGEO_IMPORTER_RASTER_FILES', os.path.join(MEDIA_ROOT,'osgeo_importer_raster'))
+UPLOAD_DIR = getattr(settings, 'OSGEO_IMPORTER_UPLOAD_DIR', os.path.join(MEDIA_ROOT,'osgeo_importer_uploads'))
 
+if not os.path.exists(RASTER_FILES):
+    os.makedirs(RASTER_FILES)
+
+if not os.path.exists(UPLOAD_DIR):
+    os.makedirs(UPLOAD_DIR)
 
 class Import(object):
     """
@@ -37,8 +48,7 @@ class Import(object):
     enabled_handlers = IMPORT_HANDLERS
     source_inspectors = []
     target_inspectors = []
-    valid_extensions = ['gpx', 'geojson', 'json', 'zip', 'tar', 'kml', 'csv', 'shp',
-                        'tif', 'tiff', 'geotiff', 'gpkg']
+    valid_extensions = VALID_EXTENSIONS
 
     def filter_handler_results(self, handler_name):
         """

--- a/osgeo_importer/importers.py
+++ b/osgeo_importer/importers.py
@@ -25,17 +25,18 @@ ogr.UseExceptions()
 
 MEDIA_ROOT = getattr(settings, 'MEDIA_ROOT', FileSystemStorage().location)
 OSGEO_IMPORTER = getattr(settings, 'OSGEO_IMPORTER', 'osgeo_importer.importers.OGRImport')
-VALID_EXTENSIONS = getattr(settings, 'OSGEO_IMPORTER_VALID_EXTENSIONS', 
-                           ['shp','shx','prj','dbf','kml','geojson','json',
-                           'tif','tiff','gpkg','csv','zip','xml','sld'])
-RASTER_FILES = getattr(settings, 'OSGEO_IMPORTER_RASTER_FILES', os.path.join(MEDIA_ROOT,'osgeo_importer_raster'))
-UPLOAD_DIR = getattr(settings, 'OSGEO_IMPORTER_UPLOAD_DIR', os.path.join(MEDIA_ROOT,'osgeo_importer_uploads'))
+VALID_EXTENSIONS = getattr(settings, 'OSGEO_IMPORTER_VALID_EXTENSIONS',
+                           ['shp', 'shx', 'prj', 'dbf', 'kml', 'geojson', 'json',
+                            'tif', 'tiff', 'gpkg', 'csv', 'zip', 'xml', 'sld'])
+RASTER_FILES = getattr(settings, 'OSGEO_IMPORTER_RASTER_FILES', os.path.join(MEDIA_ROOT, 'osgeo_importer_raster'))
+UPLOAD_DIR = getattr(settings, 'OSGEO_IMPORTER_UPLOAD_DIR', os.path.join(MEDIA_ROOT, 'osgeo_importer_uploads'))
 
 if not os.path.exists(RASTER_FILES):
     os.makedirs(RASTER_FILES)
 
 if not os.path.exists(UPLOAD_DIR):
     os.makedirs(UPLOAD_DIR)
+
 
 class Import(object):
     """

--- a/osgeo_importer/migrations/0003_uploadlayer_upload_file.py
+++ b/osgeo_importer/migrations/0003_uploadlayer_upload_file.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osgeo_importer', '0002_auto_20160713_1429'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='uploadlayer',
+            name='upload_file',
+            field=models.ForeignKey(blank=True, to='osgeo_importer.UploadFile', null=True),
+        ),
+    ]

--- a/osgeo_importer/migrations/0004_uploadfile_file_type.py
+++ b/osgeo_importer/migrations/0004_uploadfile_file_type.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osgeo_importer', '0003_uploadlayer_upload_file'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='uploadfile',
+            name='file_type',
+            field=models.CharField(max_length=50, null=True, blank=True),
+        ),
+    ]

--- a/osgeo_importer/migrations/0005_uploadlayer_layer_name.py
+++ b/osgeo_importer/migrations/0005_uploadlayer_layer_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osgeo_importer', '0004_uploadfile_file_type'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='uploadlayer',
+            name='layer_name',
+            field=models.CharField(max_length=64, null=True),
+        ),
+    ]

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -31,7 +31,6 @@ from django.db import models
 from djcelery.models import TaskState
 from jsonfield import JSONField
 
-
 try:
     from django.contrib.contenttypes.fields import GenericForeignKey
 except ImportError:
@@ -179,11 +178,33 @@ class UploadedData(models.Model):
         return 'Upload [%s] %s, %s' % (self.id, self.name, self.user)
 
 
+class UploadFile(models.Model):
+    upload = models.ForeignKey(UploadedData, null=True, blank=True)
+    file = models.FileField(upload_to="uploads", validators=[validate_file_extension, validate_inspector_can_read])
+    slug = models.SlugField(max_length=250, blank=True)
+
+    def __unicode__(self):
+        return self.slug
+
+    @property
+    def name(self):
+        return os.path.basename(self.file.path)
+
+    def save(self, *args, **kwargs):
+        self.slug = self.file.name
+        super(UploadFile, self).save(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        self.file.delete(False)
+        super(UploadFile, self).delete(*args, **kwargs)
+
+
 class UploadLayer(models.Model):
     """
     Layers stored in an uploaded data set.
     """
     upload = models.ForeignKey(UploadedData, null=True, blank=True)
+    upload_file = models.ForeignKey(UploadFile, null=True, blank=True)
     index = models.IntegerField(default=0)
     name = models.CharField(max_length=64, null=True)
     fields = JSONField(null=True, default={})
@@ -235,27 +256,6 @@ class UploadLayer(models.Model):
 
     class Meta:
         ordering = ('index',)
-
-
-class UploadFile(models.Model):
-    upload = models.ForeignKey(UploadedData, null=True, blank=True)
-    file = models.FileField(upload_to="uploads", validators=[validate_file_extension, validate_inspector_can_read])
-    slug = models.SlugField(max_length=250, blank=True)
-
-    def __unicode__(self):
-        return self.slug
-
-    @property
-    def name(self):
-        return os.path.basename(self.file.path)
-
-    def save(self, *args, **kwargs):
-        self.slug = self.file.name
-        super(UploadFile, self).save(*args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        self.file.delete(False)
-        super(UploadFile, self).delete(*args, **kwargs)
 
 
 class UploadException(models.Model):

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -172,6 +172,7 @@ class UploadedData(models.Model):
 class UploadFile(models.Model):
     upload = models.ForeignKey(UploadedData, null=True, blank=True)
     file = models.FileField(upload_to="uploads", validators=[validate_file_extension, validate_inspector_can_read])
+    file_type = models.CharField(max_length=50, null=True, blank=True)
     slug = models.SlugField(max_length=250, blank=True)
 
     def __unicode__(self):
@@ -204,6 +205,14 @@ class UploadLayer(models.Model):
     configuration_options = JSONField(null=True)
     task_id = models.CharField(max_length=36, blank=True, null=True)
     feature_count = models.IntegerField(null=True, blank=True)
+
+    @property
+    def file_type(self):
+        """A layer's 'file type' - really the file type of the file it is in.
+        """
+        if not self.upload_file:
+            return None
+        return self.upload_file.file_type
 
     @property
     def layer_data(self):

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -79,6 +79,7 @@ def validate_inspector_can_read(value):
     """
     Validates Geospatial data.
     """
+    logger.debug('Inspecting Can Read %s',value.name)
     name = value.name
     root, extension = os.path.splitext(name.lower())
 

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -149,15 +149,9 @@ class UploadedData(models.Model):
     def filesize(self):
         """Humanizes the upload file size.
         """
-        size = 0
-        if not self.size:
-            if self.uploadfile_set.count() > 0:
-                for uploadfile in self.uploadfile_set.all():
-                    size += uploadfile.file.size
-                else:
-                    size = self.uploadfile_set.first().file.size
-            self.size = size
-        self.save()
+        # whereof one cannot speak, one must be silent
+        if self.size is None:
+            return None
         return sizeof_fmt(self.size)
 
     def file_url(self):

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -205,6 +205,7 @@ class UploadLayer(models.Model):
     configuration_options = JSONField(null=True)
     task_id = models.CharField(max_length=36, blank=True, null=True)
     feature_count = models.IntegerField(null=True, blank=True)
+    layer_name = models.CharField(max_length=64, null=True)
 
     @property
     def file_name(self):

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -150,22 +150,20 @@ class UploadedData(models.Model):
         """
         Humanizes the upload file size.
         """
-        if not self.size:
-            uploaded_file = self.uploadfile_set.first()
-
-            if uploaded_file:
-                self.size = uploaded_file.file.size
-                self.save()
-            else:
-                return
-
+        size = 0
+        if not self.size or self.size == 0:
+            if self.uploadfile_set.count() > 0:
+                for uf in self.uploadfile_set.all():
+                    size += uf.file.size
+        self.size = size
+        self.save()
         return sizeof_fmt(self.size)
 
     def file_url(self):
         """
         Exposes the file url.
         """
-        return self.uploadfile_set.first().file.url
+        return '' # self.uploadfile_set.first().file.url
 
     def any_layers_imported(self):
         return any(self.uploadlayer_set.all().values_list('layer', flat=True))

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -154,7 +154,9 @@ class UploadedData(models.Model):
             if self.uploadfile_set.count() > 0:
                 for uploadfile in self.uploadfile_set.all():
                     size += uploadfile.file.size
-        self.size = size
+                else:
+                    size = self.uploadfile_set.first().file.size
+            self.size = size
         self.save()
         return sizeof_fmt(self.size)
 

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -78,7 +78,6 @@ def validate_inspector_can_read(value):
     """
     Validates Geospatial data.
     """
-    logger.debug('Inspecting Can Read %s',value.name)
     name = value.name
     root, extension = os.path.splitext(name.lower())
 

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -163,7 +163,7 @@ class UploadedData(models.Model):
         """
         Exposes the file url.
         """
-        return '' # self.uploadfile_set.first().file.url
+        return ''  # self.uploadfile_set.first().file.url
 
     def any_layers_imported(self):
         return any(self.uploadlayer_set.all().values_list('layer', flat=True))

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -147,21 +147,19 @@ class UploadedData(models.Model):
 
     @property
     def filesize(self):
-        """
-        Humanizes the upload file size.
+        """Humanizes the upload file size.
         """
         size = 0
-        if not self.size or self.size == 0:
+        if not self.size:
             if self.uploadfile_set.count() > 0:
-                for uf in self.uploadfile_set.all():
-                    size += uf.file.size
+                for uploadfile in self.uploadfile_set.all():
+                    size += uploadfile.file.size
         self.size = size
         self.save()
         return sizeof_fmt(self.size)
 
     def file_url(self):
-        """
-        Exposes the file url.
+        """Exposes the file url.
         """
         return ''  # self.uploadfile_set.first().file.url
 
@@ -197,8 +195,7 @@ class UploadFile(models.Model):
 
 
 class UploadLayer(models.Model):
-    """
-    Layers stored in an uploaded data set.
+    """Layers stored in an uploaded data set.
     """
     upload = models.ForeignKey(UploadedData, null=True, blank=True)
     upload_file = models.ForeignKey(UploadFile, null=True, blank=True)

--- a/osgeo_importer/models.py
+++ b/osgeo_importer/models.py
@@ -207,6 +207,12 @@ class UploadLayer(models.Model):
     feature_count = models.IntegerField(null=True, blank=True)
 
     @property
+    def file_name(self):
+        if not self.upload_file:
+            return None
+        return self.upload_file.name
+
+    @property
     def file_type(self):
         """A layer's 'file type' - really the file type of the file it is in.
         """

--- a/osgeo_importer/static/osgeo_importer/partials/upload.html
+++ b/osgeo_importer/static/osgeo_importer/partials/upload.html
@@ -41,7 +41,7 @@
                                             </div>
                                             <div>
                                                 <span class="col-md-3 layer-upload-field-name">Status</span>
-                                                <span class="col-md-9">{{layer.status}}</span>
+                                                <span class="col-md-9">{{layer.status || "UNKNOWN" }}</span>
                                             </div>
                                         </div>
 

--- a/osgeo_importer/static/osgeo_importer/partials/upload.html
+++ b/osgeo_importer/static/osgeo_importer/partials/upload.html
@@ -35,7 +35,7 @@
                                                 <span class="col-md-3 layer-upload-field-name">File Type</span>
                                                 <span class="col-md-9">{{layer.file_type || upload.file_type || "UNKNOWN" }}</span>
                                             </div>
-                                            <div>
+                                            <div ng-show="layer.feature_count">
                                                 <span class="col-md-3 layer-upload-field-name">Features</span>
                                                 <span class="col-md-9">{{layer.feature_count | number : 0}}</span>
                                             </div>

--- a/osgeo_importer/static/osgeo_importer/partials/upload.html
+++ b/osgeo_importer/static/osgeo_importer/partials/upload.html
@@ -8,8 +8,8 @@
                     </div>
                     <div class="section-box-subtitle">
                         <div class="user-data-metadata">
-                                {{upload.date | date:"MMM d yyyy"}}
-                                <span class="pull-right">{{upload.file_size}}</span>
+                                {{upload.date | date:"MMM d yyyy HH:mm:ss"}}
+                                <span class="pull-right">{{upload.file_size }}</span>
                             </div>
                     </div>
                 </div>

--- a/osgeo_importer/static/osgeo_importer/partials/upload.html
+++ b/osgeo_importer/static/osgeo_importer/partials/upload.html
@@ -31,7 +31,7 @@
                                         <div class="layer-upload-details col-md-12">
                                             <div>
                                                 <span class="col-md-3 layer-upload-field-name">File Type</span>
-                                                <span class="col-md-9">{{upload.file_type}}</span>
+                                                <span class="col-md-9">{{layer.file_type || upload.file_type || "UNKNOWN" }}</span>
                                             </div>
                                             <div>
                                                 <span class="col-md-3 layer-upload-field-name">Features</span>

--- a/osgeo_importer/static/osgeo_importer/partials/upload.html
+++ b/osgeo_importer/static/osgeo_importer/partials/upload.html
@@ -3,7 +3,7 @@
             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 section-box">
                 <div class="import-head" ng-click="showDetails=!showDetails">
                     <div class="import-title light-bold">
-                        {{ upload.name }}
+                        {{ upload.name || "[multiple files]" }}
                         <span class="pull-right"><i ng-show="'{{upload.all_layers_imported}}' === 'True'" class="fa fa-check pull-right" style="color:#3D9970;"></i></span>
                     </div>
                     <div class="section-box-subtitle">

--- a/osgeo_importer/static/osgeo_importer/partials/upload.html
+++ b/osgeo_importer/static/osgeo_importer/partials/upload.html
@@ -23,7 +23,9 @@
                                 <!--<div class="light-bold">Layers</div>-->
 
                                 <div class="col-xs-10 col-sm-10 col-md-10 col-lg-10 col-xs-offset-1 col-sm-offset-1 col-md-offset-1 col-lg-offset-1 layer-in-upload" ng-repeat="layer in upload.layers">
-                                    <div class="layer-upload-name"> {{layer.name}}
+                                    <div class="layer-upload-name">
+                                        <span>{{layer.layer_name || layer.file_name}}</span>
+                                        <span ng-show="layer.layer_name && layer.layer_name != layer.file_name"><br>(in {{layer.file_name}})</span>
                                         <span class="pull-right" ng-show="layer.geonode_layer.title"><span style="font-weight: 600">Layer:</span> <a href="{{layer.geonode_layer.url}}" target="_self">{{layer.geonode_layer.title}}</a></span>
                                     </div>
                                     <hr/>

--- a/osgeo_importer/templates/osgeo_importer/new.html
+++ b/osgeo_importer/templates/osgeo_importer/new.html
@@ -39,6 +39,9 @@
             {% for error in form.file.errors %}
                 <i class="fa fa-warning">  {{ error|escape }}</i>
             {% endfor %}
+                <div class="col-md-6" style="padding-top: 5px; padding-left: 2px;">
+                    Valid file extensions: {{ VALID_EXTENSIONS }}
+                </div>
             </div>
 
         </div>

--- a/osgeo_importer/templates/osgeo_importer/new.html
+++ b/osgeo_importer/templates/osgeo_importer/new.html
@@ -32,7 +32,7 @@
             {{form}}
         </div>
         <div class="row">
-            <button type="button" class="btn-info col-md-4 btn" onclick="chooseFile();">choose file</button>
+            <button type="button" class="btn-info col-md-4 btn" onclick="chooseFile();">choose file(s)</button>
         </div>
         <div class="row">
             <div class="errorlist">

--- a/osgeo_importer/templates/osgeo_importer/new.html
+++ b/osgeo_importer/templates/osgeo_importer/new.html
@@ -40,9 +40,6 @@
                 <i class="fa fa-warning">  {{ error|escape }}</i>
             {% endfor %}
             </div>
-            <div class="col-md-6" style="padding-top: 5px; padding-left: 2px;">
-                Valid file types are .csv, .geojson, .gpx, .kml, .tif, zipped Shapefile.
-            </div>
 
         </div>
         </form>

--- a/osgeo_importer/test_views.py
+++ b/osgeo_importer/test_views.py
@@ -1,0 +1,81 @@
+from django.test import TestCase
+from osgeo_importer import views
+from osgeo_importer import models
+
+
+class TestFileAddView_upload(TestCase):
+    """Test the helper method FileAddView.upload.
+    """
+
+    class FakeRequest(object):
+        """Fake the kind of request object used by FileAddView.upload.
+        """
+        def __init__(self, user):
+            self.user = user
+
+    class FakeFile(object):
+        """Fake the kind of file object used by FileAddView.upload.
+        """
+        def __init__(self, name):
+            self.name = name
+
+    def view(self):
+        view = views.FileAddView()
+        view.get_file_type = lambda path: "BogusType"
+        user = None
+        view.request = self.FakeRequest(user)
+        return view
+
+    def test_empty(self):
+        """Empty data should return None.
+
+        Form validation should guard against this sort of argument coming to
+        upload(), but if it does happen, upload() should behave reasonably.
+        """
+        data = []
+        view = self.view()
+        upload = view.upload(data)
+        self.assertEqual(upload.name, None)
+        self.assertEqual(upload.file_type, None)
+
+    def test_single(self):
+        data = [
+            self.FakeFile("/tmp/xyz/abc/foo.shp")
+        ]
+        view = self.view()
+        upload = view.upload(data)
+        self.assertEqual(upload.name, "foo.shp")
+        self.assertEqual(upload.file_type, "BogusType")
+
+    def test_double(self):
+        data = [
+            self.FakeFile("/tmp/xyz/abc/foo.shp"),
+            self.FakeFile("/tmp/xyz/abc/bar.shp")
+        ]
+        view = self.view()
+        upload = view.upload(data)
+        self.assertEqual(upload.name, "bar.shp, foo.shp")
+        self.assertEqual(upload.file_type, None)
+
+    def test_single_too_long(self):
+        max_length = models.UploadedData._meta.get_field('name').max_length
+        too_long = "ObviouslyWayWayWayWayWayWayWayWayWayWayWayWayWayWayTooLong"
+        self.assertGreater(too_long, max_length)
+        data = [
+            self.FakeFile("/tmp/{0}".format(too_long))
+        ]
+        view = self.view()
+        upload = view.upload(data)
+        self.assertEqual(upload.name.startswith("Obviously"), True)
+        self.assertEqual(upload.file_type, "BogusType")
+
+    def test_many_too_long(self):
+        data = [
+            self.FakeFile("/tmp/xyz/abc/NotTooLongOnItsOwn.shp"),
+            self.FakeFile("/tmp/xyz/abc/rather_long_to_be_combined_with.shp"),
+            self.FakeFile("/tmp/really_too_much.shp"),
+        ]
+        view = self.view()
+        upload = view.upload(data)
+        self.assertEqual(upload.name, None)
+        self.assertEqual(upload.file_type, None)

--- a/osgeo_importer/tests.py
+++ b/osgeo_importer/tests.py
@@ -22,7 +22,7 @@ from geonode.layers.models import Layer
 from geonode.geoserver.helpers import ogc_server_settings
 from osgeo_importer.models import UploadLayer
 from osgeo_importer.models import validate_file_extension, ValidationError, validate_inspector_can_read
-from osgeo_importer.models import UploadedData
+from osgeo_importer.models import UploadedData, UploadFile
 from osgeo_importer.handlers.geoserver import GeoWebCacheHandler
 from osgeo_importer.importers import OSGEO_IMPORTER, OGRImport
 
@@ -775,6 +775,8 @@ class UploaderTests(DjagnoOsgeoMixin):
         name = 'point-with-a-date'
         with open(f) as fp:
             response = c.post(reverse('uploads-new'), {'file': fp}, follow=True)
+
+        print UploadFile.objects.first()
 
         payload = {'index': 0,
                    'convert_to_date': ['date'],

--- a/osgeo_importer/tests.py
+++ b/osgeo_importer/tests.py
@@ -249,6 +249,7 @@ class UploaderTests(DjagnoOsgeoMixin):
         upfiles_count = UploadFile.objects.filter(upload=upload_id).count()
         self.assertEqual(6,upfiles_count)
 
+        # Warning: this assumes that Layer pks equal UploadLayer pks
         layer = Layer.objects.get(pk=layerid)
         gslayer = self.cat.get_layer(layer.name)
         default_style = gslayer.default_style

--- a/osgeo_importer/tests.py
+++ b/osgeo_importer/tests.py
@@ -147,6 +147,57 @@ class UploaderTests(DjagnoOsgeoMixin):
 
         return layer_results[0]
 
+    def generic_api_upload(self, files, configuration_options=None):
+        """
+        Tests the import api.
+        """
+        c = AdminClient()
+        c.login_as_non_admin()
+        
+        # Upload Files
+        if isinstance(files, type(str())):
+            files = [files]
+        outfiles = []
+        handles = {}
+        for file in files:
+            f = os.path.join(
+                os.path.dirname(__file__),
+                '..',
+                'importer-test-files',
+                file)
+            handles[file] = open(f)
+            outfiles.append(SimpleUploadedFile(file, handles[file].read()))
+        response = c.post(
+            reverse('uploads-new-json'),
+            {'file': outfiles,
+             'json': json.dumps(configuration_options)},
+            follow=True)
+        # Clean up file handles
+        for file, handle in handles.items():
+            handle.close()
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content['id'], 1)
+
+        # Configure Uploaded Files
+        uploadid = content['id']
+        upload_layers = UploadLayer.objects.filter(upload_id=uploadid)
+        
+        for upload_layer in upload_layers:
+            print upload_layer.id
+            print upload_layer.name
+            for config in configuration_options:
+                if config['upload_file_name'] == upload_layer.name:
+                    payload = config['config']
+                    response = c.post('/importer-api/data-layers/{0}/configure/'.format(upload_layer.id), data=json.dumps(payload),
+                                   content_type='application/json')
+                    self.assertTrue(response.status_code, 200)
+                    response = c.get('/importer-api/data-layers/{0}/'.format(upload_layer.id),
+                                   content_type='application/json')
+                    self.assertTrue(response.status_code, 200)
+
+        return content
+
     def generic_raster_import(self, file, configuration_options=[{'index': 0}]):
         f = file
         filename = os.path.join(os.path.dirname(__file__), '..', 'importer-test-files', f)
@@ -159,6 +210,70 @@ class UploaderTests(DjagnoOsgeoMixin):
         l = gdal.OpenEx(layerfile)
         self.assertTrue(l.GetDriver().ShortName, 'GTiff')
         return layer
+
+    def test_multi_upload(self):
+        """
+        Tests Uploading Multiple Files
+        """
+        upload = self.generic_api_upload(
+            ['boxes_with_year_field.zip',
+             'boxes_with_date.zip',
+             'point_with_date.geojson'],
+              [{'upload_file_name': 'boxes_with_year_field.shp',
+                'config': [{'index': 0}]},
+               {'upload_file_name': 'boxes_with_date.shp',
+               'config': [{'index': 0}]},
+               {'upload_file_name': 'point_with_date.geojson',
+                'config': [{'index': 0}]}
+               ]
+        )
+        self.assertEqual(9, upload['count'])
+
+    def test_upload_with_slds(self):
+        """
+        Tests Uploading sld
+        """
+        upload = self.generic_api_upload(
+            ['boxes_with_date.zip',
+             'boxes.sld',
+             'boxes1.sld'],
+              [{'upload_file_name': 'boxes_with_date.shp',
+               'config': [{'index': 0, 'default_style': 'boxes.sld',
+                           'styles': ['boxes.sld', 'boxes1.sld']}]}
+               ]
+        )
+        self.assertEqual(6, upload['count'])
+        uploadid = upload['id']
+        uploadobj = UploadedData.objects.get(pk=uploadid)
+        uplayers = UploadLayer.objects.filter(upload=uploadid)
+        layerid = uplayers[0].pk
+
+        upfiles_cnt = UploadFile.objects.filter(upload=uploadid).count()
+        self.assertEqual(6,upfiles_cnt)
+
+        layer = Layer.objects.get(pk=layerid)
+        gslayer = self.cat.get_layer(layer.name)
+        default_style = gslayer.default_style
+        self.cat._cache.clear()
+        self.assertEqual('boxes.sld',default_style.filename)
+
+    def test_upload_with_metadata(self):
+        """
+        Tests Uploading metadata
+        """
+        upload = self.generic_api_upload(
+            ['boxes_with_date.zip',
+             'samplemetadata.xml',],
+              [{'upload_file_name': 'boxes_with_date.shp',
+               'config': [{'index': 0, 'metadata': 'samplemetadata.xml'}]}
+               ]
+        )
+        self.assertEqual(5, upload['count'])
+        print upload
+        layerid = upload['uploaded'][0]['pk'];
+        layer = Layer.objects.get(pk=layerid)
+        self.assertEqual(layer.language, 'eng')
+        self.assertEqual(layer.title, 'Old_Americas_LSIB_Polygons_Detailed_2013Mar')
 
     def test_raster(self):
         """
@@ -505,10 +620,10 @@ class UploaderTests(DjagnoOsgeoMixin):
         self.assertTrue(len(response.context['object_list']) == 1)
         upload = response.context['object_list'][0]
         self.assertEqual(upload.user.username, 'non_admin')
-        self.assertEqual(upload.file_type, 'GeoJSON')
+        # self.assertEqual(upload.file_type, 'GeoJSON')
         self.assertTrue(upload.uploadlayer_set.all())
         self.assertEqual(upload.state, 'UPLOADED')
-        self.assertIsNotNone(upload.name)
+        # self.assertIsNotNone(upload.name)
 
         uploaded_file = upload.uploadfile_set.first()
         self.assertTrue(os.path.exists(uploaded_file.file.path))
@@ -775,8 +890,6 @@ class UploaderTests(DjagnoOsgeoMixin):
         name = 'point-with-a-date'
         with open(f) as fp:
             response = c.post(reverse('uploads-new'), {'file': fp}, follow=True)
-
-        print UploadFile.objects.first()
 
         payload = {'index': 0,
                    'convert_to_date': ['date'],

--- a/osgeo_importer/tests.py
+++ b/osgeo_importer/tests.py
@@ -184,8 +184,6 @@ class UploaderTests(DjagnoOsgeoMixin):
         upload_layers = UploadLayer.objects.filter(upload_id=uploadid)
         
         for upload_layer in upload_layers:
-            print upload_layer.id
-            print upload_layer.name
             for config in configuration_options:
                 if config['upload_file_name'] == upload_layer.name:
                     payload = config['config']
@@ -269,8 +267,14 @@ class UploaderTests(DjagnoOsgeoMixin):
                ]
         )
         self.assertEqual(5, upload['count'])
-        print upload
-        layerid = upload['uploaded'][0]['pk'];
+        uploadid = upload['id']
+        uploadobj = UploadedData.objects.get(pk=uploadid)
+        uplayers = UploadLayer.objects.filter(upload=uploadid)
+        layerid = uplayers[0].pk
+
+        upfiles_cnt = UploadFile.objects.filter(upload=uploadid).count()
+        self.assertEqual(5,upfiles_cnt)
+
         layer = Layer.objects.get(pk=layerid)
         self.assertEqual(layer.language, 'eng')
         self.assertEqual(layer.title, 'Old_Americas_LSIB_Polygons_Detailed_2013Mar')

--- a/osgeo_importer/tests.py
+++ b/osgeo_importer/tests.py
@@ -148,12 +148,11 @@ class UploaderTests(DjagnoOsgeoMixin):
         return layer_results[0]
 
     def generic_api_upload(self, files, configuration_options=None):
-        """
-        Tests the import api.
+        """Tests the import api.
         """
         c = AdminClient()
         c.login_as_non_admin()
-        
+
         # Upload Files
         if isinstance(files, type(str())):
             files = [files]
@@ -180,18 +179,21 @@ class UploaderTests(DjagnoOsgeoMixin):
         self.assertEqual(content['id'], 1)
 
         # Configure Uploaded Files
-        uploadid = content['id']
-        upload_layers = UploadLayer.objects.filter(upload_id=uploadid)
-        
+        upload_id = content['id']
+        upload_layers = UploadLayer.objects.filter(upload_id=upload_id)
+
         for upload_layer in upload_layers:
             for config in configuration_options:
                 if config['upload_file_name'] == upload_layer.name:
                     payload = config['config']
-                    response = c.post('/importer-api/data-layers/{0}/configure/'.format(upload_layer.id), data=json.dumps(payload),
-                                   content_type='application/json')
+                    url = '/importer-api/data-layers/{0}/configure/'.format(upload_layer.id)
+                    response = c.post(
+                        url, data=json.dumps(payload),
+                        content_type='application/json'
+                    )
                     self.assertTrue(response.status_code, 200)
-                    response = c.get('/importer-api/data-layers/{0}/'.format(upload_layer.id),
-                                   content_type='application/json')
+                    url = '/importer-api/data-layers/{0}/'.format(upload_layer.id)
+                    response = c.get(url, content_type='application/json')
                     self.assertTrue(response.status_code, 200)
 
         return content
@@ -210,8 +212,7 @@ class UploaderTests(DjagnoOsgeoMixin):
         return layer
 
     def test_multi_upload(self):
-        """
-        Tests Uploading Multiple Files
+        """Tests Uploading Multiple Files
         """
         upload = self.generic_api_upload(
             ['boxes_with_year_field.zip',
@@ -228,8 +229,7 @@ class UploaderTests(DjagnoOsgeoMixin):
         self.assertEqual(9, upload['count'])
 
     def test_upload_with_slds(self):
-        """
-        Tests Uploading sld
+        """Tests Uploading sld
         """
         upload = self.generic_api_upload(
             ['boxes_with_date.zip',
@@ -241,13 +241,13 @@ class UploaderTests(DjagnoOsgeoMixin):
                ]
         )
         self.assertEqual(6, upload['count'])
-        uploadid = upload['id']
-        uploadobj = UploadedData.objects.get(pk=uploadid)
-        uplayers = UploadLayer.objects.filter(upload=uploadid)
+        upload_id = upload['id']
+        upload_obj = UploadedData.objects.get(pk=upload_id)
+        uplayers = UploadLayer.objects.filter(upload=upload_id)
         layerid = uplayers[0].pk
 
-        upfiles_cnt = UploadFile.objects.filter(upload=uploadid).count()
-        self.assertEqual(6,upfiles_cnt)
+        upfiles_count = UploadFile.objects.filter(upload=upload_id).count()
+        self.assertEqual(6,upfiles_count)
 
         layer = Layer.objects.get(pk=layerid)
         gslayer = self.cat.get_layer(layer.name)
@@ -256,8 +256,7 @@ class UploaderTests(DjagnoOsgeoMixin):
         self.assertEqual('boxes.sld',default_style.filename)
 
     def test_upload_with_metadata(self):
-        """
-        Tests Uploading metadata
+        """Tests Uploading metadata
         """
         upload = self.generic_api_upload(
             ['boxes_with_date.zip',
@@ -267,13 +266,13 @@ class UploaderTests(DjagnoOsgeoMixin):
                ]
         )
         self.assertEqual(5, upload['count'])
-        uploadid = upload['id']
-        uploadobj = UploadedData.objects.get(pk=uploadid)
-        uplayers = UploadLayer.objects.filter(upload=uploadid)
+        upload_id = upload['id']
+        upload_obj = UploadedData.objects.get(pk=upload_id)
+        uplayers = UploadLayer.objects.filter(upload=upload_id)
         layerid = uplayers[0].pk
 
-        upfiles_cnt = UploadFile.objects.filter(upload=uploadid).count()
-        self.assertEqual(5,upfiles_cnt)
+        upfiles_count = UploadFile.objects.filter(upload=upload_id).count()
+        self.assertEqual(5,upfiles_count)
 
         layer = Layer.objects.get(pk=layerid)
         self.assertEqual(layer.language, 'eng')

--- a/osgeo_importer/tests.py
+++ b/osgeo_importer/tests.py
@@ -624,10 +624,10 @@ class UploaderTests(DjagnoOsgeoMixin):
         self.assertTrue(len(response.context['object_list']) == 1)
         upload = response.context['object_list'][0]
         self.assertEqual(upload.user.username, 'non_admin')
-        # self.assertEqual(upload.file_type, 'GeoJSON')
+        self.assertEqual(upload.file_type, 'GeoJSON')
         self.assertTrue(upload.uploadlayer_set.all())
         self.assertEqual(upload.state, 'UPLOADED')
-        # self.assertIsNotNone(upload.name)
+        self.assertIsNotNone(upload.name)
 
         uploaded_file = upload.uploadfile_set.first()
         self.assertTrue(os.path.exists(uploaded_file.file.path))

--- a/osgeo_importer/validators.py
+++ b/osgeo_importer/validators.py
@@ -13,11 +13,9 @@ VALID_EXTENSIONS = getattr(settings, 'OSGEO_IMPORTER_VALID_EXTENSIONS',
 NONDATA_EXTENSIONS = ['shx','prj','dbf','xml','sld']
 
 def validate_extension(filename):
-    logger.debug('Checking Filename %s For Valid Extension',filename)
     filedir, file = os.path.split(filename)
     base, extension = os.path.splitext(file)
     extension = extension.lstrip('.').lower()
-    logger.debug('Extension: %s %s', extension, VALID_EXTENSIONS)
     if extension not in VALID_EXTENSIONS:
         return False
     else:

--- a/osgeo_importer/validators.py
+++ b/osgeo_importer/validators.py
@@ -1,16 +1,12 @@
 import os
 from .utils import NoDataSourceFound, load_handler
-from .importers import OSGEO_IMPORTER
+from .importers import OSGEO_IMPORTER, VALID_EXTENSIONS
 import logging
-from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
-VALID_EXTENSIONS = getattr(settings, 'OSGEO_IMPORTER_VALID_EXTENSIONS', 
-                           ['shp','shx','prj','dbf','kml','geojson','json',
-                           'tif','tiff','gpkg','csv','zip','xml','sld'])
+NONDATA_EXTENSIONS = ['shx', 'prj', 'dbf', 'xml', 'sld']
 
-NONDATA_EXTENSIONS = ['shx','prj','dbf','xml','sld']
 
 def validate_extension(filename):
     filedir, file = os.path.split(filename)
@@ -20,6 +16,7 @@ def validate_extension(filename):
         return False
     else:
         return True
+
 
 def validate_shapefiles_have_all_parts(filenamelist):
     shp = []
@@ -42,6 +39,7 @@ def validate_shapefiles_have_all_parts(filenamelist):
     else:
         return False
 
+
 def validate_inspector_can_read(filename):
     filedir, file = os.path.split(filename)
     base, extension = os.path.splitext(file)
@@ -53,7 +51,7 @@ def validate_inspector_can_read(filename):
         data, inspector = importer.open_source_datastore(filename)
         # Ensure the data has a geometry.
         for description in inspector.describe_fields():
-            if description.get('raster') == False and description.get('geom_type') in inspector.INVALID_GEOMETRY_TYPES:
+            if description.get('raster') is False and description.get('geom_type') in inspector.INVALID_GEOMETRY_TYPES:
                 return False
     except NoDataSourceFound:
         return False

--- a/osgeo_importer/views.py
+++ b/osgeo_importer/views.py
@@ -17,11 +17,6 @@ OSGEO_INSPECTOR = import_string(OSGEO_INSPECTOR)
 OSGEO_IMPORTER = import_string(OSGEO_IMPORTER)
 
 logger = logging.getLogger(__name__)
-if logger.handlers:
-    for handler in logger.handlers:
-        logger.removeHandler(handler)
-logging.basicConfig(filename='/vagrant/views.log', level=logging.DEBUG)
-
 
 
 class JSONResponseMixin(object):
@@ -94,15 +89,12 @@ class FileAddView(FormView, ImportHelper, JSONResponseMixin):
         outdir = os.path.join(FileSystemStorage().location,outpath)
         if not os.path.exists(outdir):
             os.makedirs(outdir)
-        logger.debug("%s",outdir)
-        logger.debug("cleaned_data: %s",form.cleaned_data)
         
         # Move all files to uploads directory using upload pk
         # Must be done for all files before saving upfile for validation
         finalfiles = []
         for each in form.cleaned_data['file']:
             tofile = os.path.join(outdir,os.path.basename(each.name))
-            logger.debug('moving %s to %s', each.name, tofile)
             shutil.move(each.name, tofile)
             finalfiles.append(tofile)
 
@@ -119,11 +111,12 @@ class FileAddView(FormView, ImportHelper, JSONResponseMixin):
                 for layer in description:
                     configuration_options = DEFAULT_LAYER_CONFIGURATION.copy()
                     configuration_options.update({'index': layer.get('index')})
-                    upload.uploadlayer_set.add(UploadLayer(name=upfile_basename,
-                                                        fields=layer.get('fields', {}),
-                                                        index=layer.get('index'),
-                                                        feature_count=layer.get('feature_count',None),
-                                                        configuration_options=configuration_options))
+                    upload.uploadlayer_set.add(UploadLayer(upload_file=upfile,
+                                                           name=upfile_basename,
+                                                           fields=layer.get('fields', {}),
+                                                           index=layer.get('index'),
+                                                           feature_count=layer.get('feature_count',None),
+                                                           configuration_options=configuration_options))
         upload.complete = True
         upload.state = 'UPLOADED'
         upload.save()

--- a/osgeo_importer/views.py
+++ b/osgeo_importer/views.py
@@ -9,7 +9,7 @@ from django.core.urlresolvers import reverse_lazy
 from django.utils.text import Truncator
 from .forms import UploadFileForm
 from .models import UploadedData, UploadLayer, UploadFile, DEFAULT_LAYER_CONFIGURATION
-from .importers import OSGEO_IMPORTER
+from .importers import OSGEO_IMPORTER, VALID_EXTENSIONS
 from .inspectors import OSGEO_INSPECTOR
 from .utils import import_string, NoDataSourceFound
 from django.core.files.storage import FileSystemStorage
@@ -224,6 +224,9 @@ class FileAddView(FormView, ImportHelper, JSONResponseMixin):
         return super(FileAddView, self).form_valid(form)
 
     def render_to_response(self, context, **response_kwargs):
+
+        # grab list of valid importer extensions for use in templates
+        context["VALID_EXTENSIONS"] = ", ".join(VALID_EXTENSIONS)
 
         if self.json:
             context = {'errors': context['form'].errors}

--- a/osgeo_importer/views.py
+++ b/osgeo_importer/views.py
@@ -197,10 +197,13 @@ class FileAddView(FormView, ImportHelper, JSONResponseMixin):
                 for layer in description:
                     configuration_options = DEFAULT_LAYER_CONFIGURATION.copy()
                     configuration_options.update({'index': layer.get('index')})
+                    layer_basename = os.path.basename(
+                        layer.get('layer_name') or ''
                     )
                     upload_layer = UploadLayer(
                         upload_file=upfile,
                         name=upfile_basename,
+                        layer_name=layer_basename,
                         fields=layer.get('fields', {}),
                         index=layer.get('index'),
                         feature_count=layer.get('feature_count', None),

--- a/osgeo_importer/views.py
+++ b/osgeo_importer/views.py
@@ -98,8 +98,10 @@ class FileAddView(FormView, ImportHelper, JSONResponseMixin):
             finalfiles.append(tofile)
 
         # Loop through and create uploadfiles and uploadlayers
+        upfiles = []
         for each in finalfiles:
             upfile = UploadFile.objects.create(upload=upload)
+            upfiles.append(upfile)
             upfile.file.name = each
             upfile.save()
             upfile_basename = os.path.basename(each)
@@ -119,6 +121,9 @@ class FileAddView(FormView, ImportHelper, JSONResponseMixin):
                             configuration_options=configuration_options
                         )
                     )
+        upload.size = sum(
+            upfile.file.size for upfile in upfiles
+        )
         upload.complete = True
         upload.state = 'UPLOADED'
         upload.save()

--- a/osgeo_importer/views.py
+++ b/osgeo_importer/views.py
@@ -109,12 +109,16 @@ class FileAddView(FormView, ImportHelper, JSONResponseMixin):
                 for layer in description:
                     configuration_options = DEFAULT_LAYER_CONFIGURATION.copy()
                     configuration_options.update({'index': layer.get('index')})
-                    upload.uploadlayer_set.add(UploadLayer(upload_file=upfile,
-                                                           name=upfile_basename,
-                                                           fields=layer.get('fields', {}),
-                                                           index=layer.get('index'),
-                                                           feature_count=layer.get('feature_count', None),
-                                                           configuration_options=configuration_options))
+                    upload.uploadlayer_set.add(
+                        UploadLayer(
+                            upload_file=upfile,
+                            name=upfile_basename,
+                            fields=layer.get('fields', {}),
+                            index=layer.get('index'),
+                            feature_count=layer.get('feature_count', None),
+                            configuration_options=configuration_options
+                        )
+                    )
         upload.complete = True
         upload.state = 'UPLOADED'
         upload.save()

--- a/osgeo_importer/views.py
+++ b/osgeo_importer/views.py
@@ -10,7 +10,6 @@ from .models import UploadedData, UploadLayer, UploadFile, DEFAULT_LAYER_CONFIGU
 from .importers import OSGEO_IMPORTER
 from .inspectors import OSGEO_INSPECTOR
 from .utils import import_string
-from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 
 OSGEO_INSPECTOR = import_string(OSGEO_INSPECTOR)
@@ -85,28 +84,27 @@ class FileAddView(FormView, ImportHelper, JSONResponseMixin):
         upload.save()
 
         # Create Upload Directory based on Upload PK
-        outpath = os.path.join('osgeo_importer_uploads',str(upload.pk))
-        outdir = os.path.join(FileSystemStorage().location,outpath)
+        outpath = os.path.join('osgeo_importer_uploads', str(upload.pk))
+        outdir = os.path.join(FileSystemStorage().location, outpath)
         if not os.path.exists(outdir):
             os.makedirs(outdir)
-        
+
         # Move all files to uploads directory using upload pk
         # Must be done for all files before saving upfile for validation
         finalfiles = []
         for each in form.cleaned_data['file']:
-            tofile = os.path.join(outdir,os.path.basename(each.name))
+            tofile = os.path.join(outdir, os.path.basename(each.name))
             shutil.move(each.name, tofile)
             finalfiles.append(tofile)
 
         # Loop through and create uploadfiles and uploadlayers
-        uplayers=[]
         for each in finalfiles:
             upfile = UploadFile.objects.create(upload=upload)
             upfile.file.name = each
             upfile.save()
             upfile_basename = os.path.basename(each)
             upfile_root, upfile_ext = os.path.splitext(upfile_basename)
-            if upfile_ext.lower() not in ['.prj','.dbf','.shx']:
+            if upfile_ext.lower() not in ['.prj', '.dbf', '.shx']:
                 description = self.get_fields(each)
                 for layer in description:
                     configuration_options = DEFAULT_LAYER_CONFIGURATION.copy()
@@ -115,14 +113,15 @@ class FileAddView(FormView, ImportHelper, JSONResponseMixin):
                                                            name=upfile_basename,
                                                            fields=layer.get('fields', {}),
                                                            index=layer.get('index'),
-                                                           feature_count=layer.get('feature_count',None),
+                                                           feature_count=layer.get('feature_count', None),
                                                            configuration_options=configuration_options))
         upload.complete = True
         upload.state = 'UPLOADED'
         upload.save()
 
         if self.json:
-            return self.render_to_json_response({'state': upload.state, 'id': upload.id, 'count': UploadFile.objects.filter(upload=upload.id).count()})
+            return self.render_to_json_response({'state': upload.state, 'id': upload.id,
+                                                 'count': UploadFile.objects.filter(upload=upload.id).count()})
 
         return super(FileAddView, self).form_valid(form)
 

--- a/osgeo_importer/views.py
+++ b/osgeo_importer/views.py
@@ -2,9 +2,11 @@ import os
 import json
 import logging
 import shutil
+import collections
 from django.http import HttpResponse
 from django.views.generic import FormView, ListView, TemplateView
 from django.core.urlresolvers import reverse_lazy
+from django.utils.text import Truncator
 from .forms import UploadFileForm
 from .models import UploadedData, UploadLayer, UploadFile, DEFAULT_LAYER_CONFIGURATION
 from .importers import OSGEO_IMPORTER
@@ -79,8 +81,86 @@ class FileAddView(FormView, ImportHelper, JSONResponseMixin):
     template_name = 'osgeo_importer/new.html'
     json = False
 
-    def form_valid(self, form):
+    def upload(self, data):
+        """Use cleaned form data to populate an unsaved upload record.
+
+        Once, each upload was just one file, so all we had to do was attach its
+        name and type to the upload, where we could display it. Since multifile
+        and geopackage supported were added, the required behavior depends on
+        what we find in the upload. That is what this method is for. For
+        example, it looks at an upload and tries to come up with a reasonably
+        mnemonic name, or else set name to None to mean there was no obvious
+        option.
+        """
+        # Do not save here, we want to leave control of that to the caller.
         upload = UploadedData.objects.create(user=self.request.user)
+        # Get a list of paths for files in this upload.
+        paths = [item.name for item in data]
+        # If there are multiple paths, see if we can boil them down to a
+        # smaller number of representative paths (ideally, just one).
+        if len(paths) > 1:
+            # Group paths by common pre-extension prefixes
+            groups = collections.defaultdict(list)
+            for path in paths:
+                group_name = os.path.splitext(path)[0]
+                groups[group_name].append(path)
+            # Check each group for "leaders" - a special filename like "a.shp"
+            # which can be understood to represent other files in the group.
+            # Map from each group name to a list of leaders in that group.
+            leader_exts = ["shp"]
+            group_leaders = {}
+            for group_name, group in groups.items():
+                leaders = [
+                    path for path in group
+                    if any(path.endswith(ext) for ext in leader_exts)
+                ]
+                if leaders:
+                    group_leaders[group_name] = leaders
+            # Rebuild paths: leaders + paths without leaders to represent them
+            leader_paths = []
+            for leaders in group_leaders.values():
+                leader_paths.extend(leaders)
+            orphan_paths = []
+            for group_name, group in groups.items():
+                if group_name not in group_leaders:
+                    orphan_paths.extend(group)
+            paths = leader_paths + orphan_paths
+
+        max_length = UploadedData._meta.get_field('name').max_length
+        # If no data, just return the instance.
+        if not paths:
+            name = None
+            file_type = None
+        # If we just have one path, that's a reasonable name for the upload.
+        # We want this case to happen as frequently as reasonable, so that we
+        # can set one reasonable name and file_type for the whole upload.
+        elif len(paths) == 1:
+            path = paths[0]
+            basename = os.path.basename(path)
+            name = Truncator(basename).chars(max_length)
+            file_type = self.get_file_type(path)
+        # Failing that, see if we can represent all the important paths within
+        # the available space, making a meaningful mnemonic that isn't
+        # misleading even though there isn't one obvious name. But if we can't
+        # even do that, no use generating misleading or useless strings here,
+        # just pass a None and let the frontend handle the lack of information.
+        else:
+            basenames = sorted(os.path.basename(path) for path in paths)
+            name = ", ".join(basenames)
+            if len(name) > max_length:
+                logger.warning(
+                    "rejecting upload name for length: {0!r} {1} > {2}"
+                    .format(name, len(name), max_length)
+                )
+                name = None
+            file_type = None
+
+        upload.name = name
+        upload.file_type = file_type
+        return upload
+
+    def form_valid(self, form):
+        upload = self.upload(form.cleaned_data['file'])
         upload.save()
 
         # Create Upload Directory based on Upload PK

--- a/osgeo_importer/views.py
+++ b/osgeo_importer/views.py
@@ -191,22 +191,22 @@ class FileAddView(FormView, ImportHelper, JSONResponseMixin):
                 upfile.file_type = None
             upfile.save()
             upfile_basename = os.path.basename(each)
-            upfile_root, upfile_ext = os.path.splitext(upfile_basename)
+            _, upfile_ext = os.path.splitext(upfile_basename)
             if upfile_ext.lower() not in ['.prj', '.dbf', '.shx']:
                 description = self.get_fields(each)
                 for layer in description:
                     configuration_options = DEFAULT_LAYER_CONFIGURATION.copy()
                     configuration_options.update({'index': layer.get('index')})
-                    upload.uploadlayer_set.add(
-                        UploadLayer(
-                            upload_file=upfile,
-                            name=upfile_basename,
-                            fields=layer.get('fields', {}),
-                            index=layer.get('index'),
-                            feature_count=layer.get('feature_count', None),
-                            configuration_options=configuration_options
-                        )
                     )
+                    upload_layer = UploadLayer(
+                        upload_file=upfile,
+                        name=upfile_basename,
+                        fields=layer.get('fields', {}),
+                        index=layer.get('index'),
+                        feature_count=layer.get('feature_count', None),
+                        configuration_options=configuration_options
+                    )
+                    upload.uploadlayer_set.add(upload_layer)
         upload.size = sum(
             upfile.file.size for upfile in upfiles
         )

--- a/osgeo_importer_prj/settings.py
+++ b/osgeo_importer_prj/settings.py
@@ -80,6 +80,9 @@ DATABASES = {
 
 OSGEO_DATASTORE = 'datastore'
 OSGEO_IMPORTER_GEONODE_ENABLED = True
-OSGEO_IMPORTER_VALID_EXTENSIONS = ['shp','shx','prj','dbf','kml','geojson','json','tif','tiff','gpkg','csv','zip','xml','sld']
+OSGEO_IMPORTER_VALID_EXTENSIONS = [
+    'shp', 'shx', 'prj', 'dbf', 'kml', 'geojson', 'json', 'tif', 'tiff',
+    'gpkg', 'csv','zip','xml','sld'
+]
 LOGGING['loggers']['osgeo_importer'] = {"handlers": ["console"], "level": "DEBUG"}
 DATABASE_ROUTERS = ['osgeo_importer_prj.dbrouters.DefaultOnlyMigrations']

--- a/osgeo_importer_prj/settings.py
+++ b/osgeo_importer_prj/settings.py
@@ -80,5 +80,6 @@ DATABASES = {
 
 OSGEO_DATASTORE = 'datastore'
 OSGEO_IMPORTER_GEONODE_ENABLED = True
+OSGEO_IMPORTER_VALID_EXTENSIONS = ['shp','shx','prj','dbf','kml','geojson','json','tif','tiff','gpkg','csv','zip','xml','sld']
 LOGGING['loggers']['osgeo_importer'] = {"handlers": ["console"], "level": "DEBUG"}
 DATABASE_ROUTERS = ['osgeo_importer_prj.dbrouters.DefaultOnlyMigrations']


### PR DESCRIPTION
_Reference @bitner's original PR at https://github.com/ProminentEdge/django-osgeo-importer/pull/39_

Adds "multifile" support to the upload process: now, multiple files can be selected after clicking "choose file(s)" on the "Add data" page. This allows upload of multiple layers at once, as well as uploading of unzipped shapefiles. A single upload can include any number of files in any mix of (supported) formats.

I've also removed the outdated list of "Valid file types" from the "Add data" page's template (ref: https://github.com/boundlessgeo/django-osgeo-importer/issues/19). This is equivalent to Exchange's current default importer (that is, no explicit list of supported file types is shown to the user at this point in the upload process), which seems acceptable at this point in development. 
