### PR TITLE
Add NITF Raster Support

### DIFF
--- a/osgeo_importer/importers.py
+++ b/osgeo_importer/importers.py
@@ -26,7 +26,8 @@ ogr.UseExceptions()
 MEDIA_ROOT = getattr(settings, 'MEDIA_ROOT', FileSystemStorage().location)
 OSGEO_IMPORTER = getattr(settings, 'OSGEO_IMPORTER', 'osgeo_importer.importers.OGRImport')
 DEFAULT_SUPPORTED_EXTENSIONS = ['shp', 'shx', 'prj', 'dbf', 'kml', 'geojson', 'json',
-                                'tif', 'tiff', 'gpkg', 'csv', 'zip', 'xml', 'sld']
+                                'tif', 'tiff', 'gpkg', 'csv', 'zip', 'xml',
+                                'sld', 'ntf', 'nitf']
 VALID_EXTENSIONS = getattr(settings, 'OSGEO_IMPORTER_VALID_EXTENSIONS', DEFAULT_SUPPORTED_EXTENSIONS)
 
 RASTER_FILES = getattr(settings, 'OSGEO_IMPORTER_RASTER_FILES', os.path.join(MEDIA_ROOT, 'osgeo_importer_raster'))

--- a/osgeo_importer/importers.py
+++ b/osgeo_importer/importers.py
@@ -41,8 +41,8 @@ if not os.path.exists(UPLOAD_DIR):
 
 class Import(object):
     """
-    Importers are responsible for opening incoming geospatial datasets (using one or many inspectors) and
-    copying features to a target location.
+    Importers are responsible for opening incoming geospatial datasets (using
+    one or many inspectors) and copying features to a target location.
 
     """
     _import_handlers = []
@@ -94,7 +94,7 @@ class Import(object):
         """
         raise FileTypeNotAllowed
 
-    def handle(self, configuration_options=[{'index': 0}], *args, **kwargs):
+    def handle(self, configuration_options=None, *args, **kwargs):
         """
         Executes the entire import process.
         1) Imports the dataset from the source dataset to the target.
@@ -105,6 +105,9 @@ class Import(object):
         import method and subsequently to the handlers.
         :return: The response from the import_file method.
         """
+        if configuration_options is None:
+            configuration_options = [{'index': 0}]
+
         layers = self.import_file(configuration_options=configuration_options)
 
         for layer, config in layers:
@@ -226,8 +229,8 @@ class OGRImport(Import):
         gdal.UseExceptions()
         configuration_options = kwargs.get('configuration_options', [{'index': 0}])
 
-        # Configuration options should be a list at this point since the importer can process multiple layers in a
-        # single import
+        # Configuration options should be a list at this point since the
+        # importer can process multiple layers in a single import
         if isinstance(configuration_options, dict):
             configuration_options = [configuration_options]
 

--- a/osgeo_importer/inspectors.py
+++ b/osgeo_importer/inspectors.py
@@ -174,7 +174,8 @@ class GDALInspector(InspectorMixin):
             opened_file = self.open()
         driver = opened_file.GetDriver().ShortName
 
-        # Get Vector Layers
+        # Get Vector Layers: if dataset contains vector layers, GetLayerCount()
+        # will return > 0
         for n in range(0, opened_file.GetLayerCount()):
             layer = opened_file.GetLayer(n)
             layer_name = layer.GetName()
@@ -200,9 +201,9 @@ class GDALInspector(InspectorMixin):
 
             description.append(layer_description)
 
-        # Get Raster Layers
-        # Get main layer
-        if opened_file.GetMetadataItem('AREA_OR_POINT'):
+        # Get Raster Layers: if they exist, RasterCount returns total band count
+        # Get main layer first
+        if opened_file.RasterCount > 0:
             layer_description = {'index': len(description),
                                  'layer_name': self.file,
                                  'path': self.file,
@@ -210,7 +211,7 @@ class GDALInspector(InspectorMixin):
                                  'driver': driver}
             description.append(layer_description)
 
-        # Get sub layers
+        # Get sub layers, if present
         raster_list = opened_file.GetSubDatasets()
         for m in range(0, raster_list.__len__()):
             layer = gdal.OpenEx(raster_list[m][0])

--- a/osgeo_importer/tests.py
+++ b/osgeo_importer/tests.py
@@ -359,8 +359,8 @@ class UploaderTests(TestCase):
         self.assertEqual(layer.language, 'eng')
         self.assertEqual(layer.title, 'Old_Americas_LSIB_Polygons_Detailed_2013Mar')
 
-    def test_raster(self):
-        """Exercise raster import.
+    def test_geotiff_raster(self):
+        """Exercise GeoTIFF raster import.
         """
         layer = self.generic_raster_import(
             'test_grid.tif',

--- a/osgeo_importer/tests.py
+++ b/osgeo_importer/tests.py
@@ -372,6 +372,12 @@ class UploaderTests(TestCase):
         )
         self.assertTrue(layer.name.startswith('test_grid'))
 
+    def test_nitf_raster(self):
+        """Tests NITF raster import
+        """
+        layer = self.generic_raster_import('test_nitf.nitf')
+        self.assertTrue(layer.name.startswith('test_nitf'))
+
     def test_box_with_year_field(self):
         """Tests the import of test_box_with_year_field.
         """


### PR DESCRIPTION
Previously, osgeo-importer assumed all rasters were GeoTIFFs; a check for a tiff-specific metadata property was the "is this a raster?" gatekeeper. This caused import of rasters without that property (e.g., NITF) to fail. With this change, all rasters with a supported driver in the environment's GDAL installation can be imported. 

As the NITF driver is compiled by default in GDAL installations, it's present in all our environments and safe to add to the default extensions whitelist here. Custom environments with additional non-default drivers like JPEG2000 can add extensions to the whitelist in their own settings.

**Note** this will fail CI until the new NITF test file is added to the S3 bucket; request for that is pending
