### PR TITLE
run Coverage from local test env

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -61,6 +61,7 @@ pip install awscli
 pip install --upgrade  numpy
 pip install --upgrade python-dateutil
 pip install flake8
+pip install coverage
 
 sudo mkdir -p -m 777 importer-test-files
 aws --no-sign-request s3 sync s3://mapstory-data/importer-test-files/ importer-test-files

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+coverage run --branch --source=osgeo_importer manage.py test osgeo_importer


### PR DESCRIPTION
Add Coverage to the Vagrant (test-runner) environment; script one-liner to make running Coverage/generating reports from said environment easier.
